### PR TITLE
Partially Address Issue #36 with New Error Message

### DIFF
--- a/com.rockwellcollins.spear/src/com/rockwellcollins/spear/typing/SpearTypeChecker.java
+++ b/com.rockwellcollins.spear/src/com/rockwellcollins/spear/typing/SpearTypeChecker.java
@@ -605,7 +605,7 @@ public class SpearTypeChecker extends SpearSwitch<Type> {
 		TupleType inputs = this.processList(new ArrayList<>(call.getSpec().getInputs()));
 
 		if (!args.equals(inputs)) {
-			error("Provided args of type " + args + ", but " + call.getSpec().getName() + " expected type " + inputs
+			error("Provided args of type " + args + ", but spec " + call.getSpec().getName() + " expected type " + inputs
 					+ ".", call, SpearPackage.Literals.SPECIFICATION_CALL__ARGS);
 			return ERROR;
 		}
@@ -625,8 +625,13 @@ public class SpearTypeChecker extends SpearSwitch<Type> {
 		TupleType inputs = this.processList(new ArrayList<>(call.getPattern().getInputs()));
 
 		if (!args.equals(inputs)) {
-			error("Provided args of type " + args + ", but " + call.getPattern().getName() + " expected type " + inputs
-					+ ".", call, SpearPackage.Literals.PATTERN_CALL__ARGS);
+			if (call.getPattern().getName() == null) {
+				error("Possible omission of 'spec' keyword in specification call.", call, 
+						SpearPackage.Literals.PATTERN_CALL__ARGS);
+			} else {
+				error("Provided args of type " + args + ", but spec " + call.getPattern().getName() + " expected type " + inputs
+						+ ".", call, SpearPackage.Literals.PATTERN_CALL__ARGS);
+			}
 			return ERROR;
 		}
 

--- a/com.rockwellcollins.spear/src/com/rockwellcollins/spear/units/SpearUnitChecker.java
+++ b/com.rockwellcollins.spear/src/com/rockwellcollins/spear/units/SpearUnitChecker.java
@@ -578,7 +578,7 @@ public class SpearUnitChecker extends SpearSwitch<Unit> {
 		TupleUnit inputs = this.processList(new ArrayList<>(sc.getSpec().getInputs()));
 
 		if (!args.equals(inputs)) {
-			error("Provided units of type " + args + ", but " + sc.getSpec().getName() + " expected units "
+			error("Provided units of type " + args + ", but spec " + sc.getSpec().getName() + " expected units "
 					+ inputs + ".", sc, SpearPackage.Literals.SPECIFICATION_CALL__ARGS);
 			return ERROR;
 		}
@@ -591,8 +591,13 @@ public class SpearUnitChecker extends SpearSwitch<Unit> {
 		TupleUnit inputs = this.processList(new ArrayList<>(pc.getPattern().getInputs()));
 
 		if (!args.equals(inputs)) {
-			error("Provided units of type " + args + ", but " + pc.getPattern().getName() + " expected units " + inputs
-					+ ".", pc, SpearPackage.Literals.PATTERN_CALL__ARGS);
+			if (pc.getPattern().getName() == null) {
+				error("Possible omission of 'spec' keyword in specification call.", pc, 
+						SpearPackage.Literals.PATTERN_CALL__ARGS);
+			} else {
+				error("Provided units of type " + args + ", but pattern " + pc.getPattern().getName() + " expected units " + inputs
+						+ ".", pc, SpearPackage.Literals.PATTERN_CALL__ARGS);
+			}
 		}
 
 		return compressTuple(this.processList(new ArrayList<>(pc.getPattern().getOutputs())));


### PR DESCRIPTION
To partially address Jen’s concerns in Issue #36, I’ve modified the unit and type validations so that:

1. The error message says “but spec/pattern [name] expected inputs”, for clarity;

2. If the name of the pattern is null, the system instead prints out “Possible omission of 'spec' keyword in specification call.”

Showing “but null expected units” isn’t really useful in any case, so instead suggesting a better fix for the problem seems good.