### PR TITLE
Fix for Issue #48

### DIFF
--- a/com.rockwellcollins.spear/src/com/rockwellcollins/Spear.xtext
+++ b/com.rockwellcollins.spear/src/com/rockwellcollins/Spear.xtext
@@ -236,6 +236,6 @@ BOOLEAN_TRUE:
 BOOLEAN_FALSE:
 	'FALSE' | 'false';
 
-REAL:
-	INT '.' INT;
+REAL hidden(): INT '.' (EXT_INT | INT);
+terminal EXT_INT: INT ('e'|'E')('-'|'+')? INT;
 


### PR DESCRIPTION
Correctly provides an exponent syntax for real numbers (not for integers).

Has been tested.